### PR TITLE
maliit: drop raspberrypi2 specific maliit-env

### DIFF
--- a/recipes-qt/maliit/files/raspberrypi2/maliit-env.conf
+++ b/recipes-qt/maliit/files/raspberrypi2/maliit-env.conf
@@ -1,3 +1,0 @@
-LANGUAGE=en_US
-QT_QPA_PLATFORM=wayland
-HOME=/var/lib/maliit

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bbappend
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bbappend
@@ -1,1 +1,0 @@
-FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/files:"


### PR DESCRIPTION
Together with
https://github.com/agherzan/meta-raspberrypi/pull/412
https://github.com/webOS-ports/meta-webos-ports/pull/333

fixes all current signatures issues detected with:
openembedded-core/scripts/sstate-diff-machines.sh --targets=luneos-dev-image --tmpdir=tmp-glibc/ --analyze --machines="raspberrypi2 raspberrypi3 mako"