### PR TITLE
nyx-modules: only bring in libcec-examples and nyx modules for CEC on Pi4

### DIFF
--- a/recipes-webos/nyx-modules/nyx-modules.bbappend
+++ b/recipes-webos/nyx-modules/nyx-modules.bbappend
@@ -1,7 +1,8 @@
 # Copyright (c) 2020-2024 LG Electronics, Inc.
 
-EXTENDPRAUTO:append:rpi = "webosrpi7"
+EXTENDPRAUTO:append:rpi = "webosrpi8"
 
-RDEPENDS:${PN}:append:rpi = " libcec-examples"
+# packagegroup-luneos-extended says CEC is only supported on pi4-64
+RDEPENDS:${PN}:append:raspberrypi4-64 = " libcec-examples"
 
-NYX_MODULES_REQUIRED:append:rpi = "NYXMOD_OW_CEC;"
+NYX_MODULES_REQUIRED:append:raspberrypi4-64 = "NYXMOD_OW_CEC;"


### PR DESCRIPTION
- Per comments in packagegroup-luneos-extended.bbappend, CEC is only supported on Pi4

I do not have hardware to test if this is actually true, but figure the code in the packagegroup should match the code in nyx-modules
